### PR TITLE
fix for window scaling issue

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -50,6 +50,9 @@ $transition: all 0.3s ease-in-out;
 
 html {
     font-size: 62.5%;
+    @media (-webkit-device-pixel-ratio: 1.25) {
+        font-size: 50%;
+    }
 }
 
 * {


### PR DESCRIPTION
closes issue #3 

The issue was easy to solve. The whole website is made with the help of rems. The initial font-size of the HTML is 62.5%. I added another media query to convert it to 50% whenever the device-pixel-ratio is 1.25. It would mean that the website wouldn't really zoom if a user manually scales it to 125% using the browser, but I find it to be acceptable. 